### PR TITLE
feat: guarantee mermaid code fences survive conversion

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -148,6 +148,17 @@ test("convertToMarkdown: throws on unsupported ContentSource type", async (t) =>
   );
 });
 
+test("convertToMarkdown: mermaid block in markdown input passes through intact", async (t) => {
+  const md = "# Diagram\n\n```mermaid\ngraph TD; A-->B;\n```\n";
+  const result = await convertToMarkdown(md, {
+    inputType: "markdown",
+    includeMeta: false,
+  });
+
+  t.true(result.markdown.includes("```mermaid"));
+  t.true(result.markdown.includes("graph TD; A-->B;"));
+});
+
 test("convertToMarkdown: returns proper MarkdownResult structure", async (t) => {
   const result = await convertToMarkdown(SIMPLE_HTML);
 

--- a/src/parsers/markdown-parser.spec.ts
+++ b/src/parsers/markdown-parser.spec.ts
@@ -888,3 +888,33 @@ test("code block: single-word class that is a known language works", (t) => {
   t.true(result.markdown.includes("```js"));
   t.true(result.markdown.includes("```py"));
 });
+
+test("code block: mermaid fences survive HTML conversion", (t) => {
+  const parser = new MarkdownParser();
+  const html = `
+    <body>
+      <pre><code class="language-mermaid">graph TD; A--&gt;B;</code></pre>
+      <pre><code class="mermaid">sequenceDiagram; A-&gt;&gt;B: hi</code></pre>
+    </body>
+  `;
+  const result = parser.convert(html);
+  // Both the language-prefixed and bare single-word class must be tagged.
+  t.is(result.markdown.match(/```mermaid/g)?.length, 2);
+  t.true(result.markdown.includes("graph TD; A-->B;"));
+  t.true(result.markdown.includes("sequenceDiagram; A->>B: hi"));
+});
+
+test("code block: other diagram languages are preserved", (t) => {
+  const parser = new MarkdownParser();
+  const html = `
+    <body>
+      <pre><code class="language-graphviz">digraph { a -> b }</code></pre>
+      <pre><code class="language-plantuml">@startuml
+A -> B
+@enduml</code></pre>
+    </body>
+  `;
+  const result = parser.convert(html);
+  t.true(result.markdown.includes("```graphviz"));
+  t.true(result.markdown.includes("```plantuml"));
+});

--- a/src/parsers/markdown-parser.ts
+++ b/src/parsers/markdown-parser.ts
@@ -135,6 +135,11 @@ const KNOWN_LANGUAGES = new Set([
   "tsv",
   "markdown",
   "md",
+  // Diagrams
+  "mermaid",
+  "dot",
+  "graphviz",
+  "plantuml",
   // Other
   "diff",
   "patch",


### PR DESCRIPTION
Fixes #19

Adds mermaid/dot/graphviz/plantuml to KNOWN_LANGUAGES so diagram fences are preserved explicitly rather than surviving only via the length heuristic. Tests cover HTML (language- prefix and bare single-word class) and the markdown-input passthrough path.